### PR TITLE
에러 메시지 출력 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "kuroshiro-browser": "^0.1.0",
         "mime": "^4.0.7",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -4339,9 +4340,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "kuroshiro-browser": "^0.1.0",
     "mime": "^4.0.7",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/src/components/MessageTable.tsx
+++ b/src/components/MessageTable.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import TranslationError from './TranslationError'
 import type { Tab } from '../types/ui'
 import type { MessageEntry } from '../types/message'
 
@@ -23,12 +24,12 @@ const MessageTable: FC<MessageTableProps> = ({ selectedTab, messages, translate 
             </td>
             <td
               className={'message' + (entry.message.includes('<ruby>') ? ' ruby' : '')}
-              colSpan={entry.translation ? 1 : 2}
+              colSpan={entry.translation || entry.translationError ? 1 : 2}
               dangerouslySetInnerHTML={{ __html: entry.message }}
               onClick={() => translate(entry.id)}
             />
             {entry.translation && <td className="translation">{entry.translation}</td>}
-            {!entry.translation && entry.translationError && <td className="translation error">{entry.translationError}</td>}
+            {!entry.translation && entry.translationError && <TranslationError translationError={entry.translationError} />}
           </tr>
         ))}
       </tbody>

--- a/src/components/TranslationError.tsx
+++ b/src/components/TranslationError.tsx
@@ -1,0 +1,33 @@
+import { FC, useMemo } from 'react'
+import z from 'zod'
+
+const errorSchema = z.object({
+  error: z.object({ code: z.number(), status: z.string(), message: z.string() }),
+})
+
+interface TranslationErrorProps {
+  translationError: string
+}
+
+const TranslationError: FC<TranslationErrorProps> = ({ translationError }) => {
+  const error = useMemo(() => {
+    try {
+      const e = errorSchema.safeParse(JSON.parse(translationError))
+      return e.success ? e.data.error : null
+    } catch {
+      return null
+    }
+  }, [translationError])
+
+  if (!error) return <td className="translation error">{translationError}</td>
+  if (error.code === 403) return <td className="translation error">접근 거부. API 키를 확인하세요.</td>
+  if (error.code === 429) return <td className="translation error">요청 초과. 잠시 후 다시 시도하세요.</td>
+
+  return (
+    <td className="translation error">
+      {error.code} {error.status}: {error.message}
+    </td>
+  )
+}
+
+export default TranslationError


### PR DESCRIPTION
fix #1

- 에러 메시지가 추가 컬럼에 삐져나와 표시되는 문제 수정
- 에러 메시지가 JSON 형식인 경우 파싱하는 절차 추가
  - 파싱 성공 시
    - 자주 발생하는 403 및 429 에러 코드에 대한 별도 메시지 출력 
    - 다른 에러 코드는 JSON 내 메시지 필드 출력
  - 파싱 실패 시 원본 에러 메시지 그대로 출력

