### PR TITLE
ACT.Hojoring 로그 제외

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import api from './functions/api'
 import { highlight } from './functions/lang'
 import createTranslator from './functions/translate'
 import { createId, scrollToBottom } from './functions/ui'
-import { getMessageCategoryByType, isCombatType } from './functions/xiv'
+import { getMessageCategoryByType, isCombatType, isExternalToolMessage } from './functions/xiv'
 import useOverlayPlugin from './hooks/useOverlayPlugin'
 import { autoTranslateAtom, geminiApiKeyAtom, isTransparentAtom } from './stores/settings'
 import type { MessageEntry } from './types/message'
@@ -54,6 +54,7 @@ function App() {
 
       const [type, sender, message] = [parseInt(event.line[2], 16), event.line[3], event.line[4]]
       if (isCombatType(type)) return
+      if (isExternalToolMessage(type, message)) return
 
       const id = createId()
       const category = getMessageCategoryByType(type)

--- a/src/constants/xiv.ts
+++ b/src/constants/xiv.ts
@@ -7,3 +7,7 @@ export const chatTypes = [
 ]
 
 export const npcDialogueTypes = [/** NPCDialogue */ 61, /** NPCDialogueAnnouncements */ 68]
+
+export const externalToolSignatures = [
+  /** ACT.UltraScouter */ { /** Echo */ type: 56, pattern: /^Hojoring>/ },
+]

--- a/src/constants/xiv.ts
+++ b/src/constants/xiv.ts
@@ -9,5 +9,5 @@ export const chatTypes = [
 export const npcDialogueTypes = [/** NPCDialogue */ 61, /** NPCDialogueAnnouncements */ 68]
 
 export const externalToolSignatures = [
-  /** ACT.UltraScouter */ { /** Echo */ type: 56, pattern: /^Hojoring>/ },
+  /** ACT.Hojoring */ { /** Echo */ type: 56, pattern: /^Hojoring>/ },
 ]

--- a/src/functions/xiv.ts
+++ b/src/functions/xiv.ts
@@ -1,10 +1,15 @@
-import { chatTypes } from '../constants/xiv'
+import { chatTypes, externalToolSignatures } from '../constants/xiv'
 import type { MessageCategory } from '../types/message'
 
 /** 전투 로그 타입인지 체크 (by Arc) */
 export const isCombatType = (type: number) => {
   const t = type & 0b0111_1111
   return 41 <= t && t <= 49
+}
+
+/** 외부 툴 메시지인지 체크 */
+export const isExternalToolMessage = (type: number, message: string) => {
+  return externalToolSignatures.some((s) => s.type === type && s.pattern.test(message))
 }
 
 /** 타입별 메시지 카테고리 분류 */


### PR DESCRIPTION
fix #3 

## 개요

- 혼잣말 메시지 중에서 내용이 `Hojoring>`으로 시작하는 메시지를 완전히 제외함
- 추후 다른 외부 툴도 제외할 수 있도록 `src/constants/xiv.ts`에 제외시킬 패턴 목록 추가

## 체크리스트

- [x] 인게임 확인
- [x] 프로덕션 배포